### PR TITLE
Fix error wrapping in EDIFACT parser

### DIFF
--- a/nodes/EdifactToJson/parser.ts
+++ b/nodes/EdifactToJson/parser.ts
@@ -6,12 +6,19 @@ export class EdifactParser {
 
     parse(): Edifact {
         try {
-            let reader = new Reader();
-            var result = reader.parse(this.document);
-            var builder = new InterchangeBuilder(result, reader.separators, '');
+            const reader = new Reader();
+            const result = reader.parse(this.document);
+            const builder = new InterchangeBuilder(result, reader.separators, '');
             return builder.interchange;
         } catch (error) {
-            throw new Error(`Failed to parse EDIFACT document: ${error.message}`, error);
+            if (error instanceof Error) {
+                // Re-throw with additional context while preserving the original error
+                throw new Error(
+                    `Failed to parse EDIFACT document: ${error.message}`,
+                    { cause: error },
+                );
+            }
+            throw error;
         }
     }
 


### PR DESCRIPTION
## Summary
- improve error handling in `EdifactParser` by preserving the original error as the cause

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_6889a9c4c7408333b4d8245f0164ab74