### PR TITLE
Move EDIFACT processing into services

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const tsJestTransformCfg = createDefaultPreset().transform;
 module.exports = {
   testEnvironment: "node",
   transform: {
-    ...tsJestTransformCfg,
+    ...tsJestTransformCfg
   },
+  testPathIgnorePatterns: ['dist']
 };

--- a/nodes/EdifactToJson/EdifactConversionService.ts
+++ b/nodes/EdifactToJson/EdifactConversionService.ts
@@ -1,0 +1,20 @@
+import { EdifactParser } from './parser';
+
+function noop() {}
+
+export class EdifactConversionService {
+    parse(edifact: string) {
+        const originalWarn = console.warn;
+        const originalError = console.error;
+        console.warn = noop;
+        console.error = noop;
+
+        try {
+            const parser = new EdifactParser(edifact, {});
+            return parser.parse();
+        } finally {
+            console.warn = originalWarn;
+            console.error = originalError;
+        }
+    }
+}

--- a/nodes/EdifactToJson/InputResolver.ts
+++ b/nodes/EdifactToJson/InputResolver.ts
@@ -1,0 +1,22 @@
+import { IExecuteFunctions, NodeOperationError } from 'n8n-workflow';
+
+export class InputResolver {
+    constructor(private ctx: IExecuteFunctions) {}
+
+    async getEdifactString(index: number): Promise<string> {
+        const inputType = this.ctx.getNodeParameter('mainInputType', index) as string;
+        if (inputType === 'string') {
+            return this.ctx.getNodeParameter('edifactInput', index) as string;
+        }
+
+        const prop = this.ctx.getNodeParameter('binaryPropertyName', index) as string;
+        const item = this.ctx.getInputData()[index];
+
+        if (!item.binary?.[prop]) {
+            throw new NodeOperationError(this.ctx.getNode(), `No binary data found for property "${prop}" on item ${index}.`, { itemIndex: index });
+        }
+
+        const buffer = await this.ctx.helpers.getBinaryDataBuffer(index, prop);
+        return buffer.toString('utf8');
+    }
+}

--- a/nodes/__tests__/EdifactConversionService.spec.ts
+++ b/nodes/__tests__/EdifactConversionService.spec.ts
@@ -1,0 +1,41 @@
+import { EdifactConversionService } from '../EdifactToJson/EdifactConversionService';
+
+describe('EdifactConversionService', () => {
+  it('parses a simple EDIFACT message', () => {
+    const sampleEdifact = `UNA:+.? '
+UNB+UNOC:3+1234567891234:14+4321987654321:14+250725:1503+38190'
+UNH+3819000001+DESADV:D:01B:UN:EAN007'
+BGM+351+DES587441+9'
+DTM+137:20020401:102'
+UNT+7+3819000001'
+UNZ+1+38190'`;
+
+    const service = new EdifactConversionService();
+    const result = service.parse(sampleEdifact);
+
+    expect(result.sender.id).toBe('1234567891234');
+    expect(result.receiver.id).toBe('4321987654321');
+  });
+
+  it('suppresses console warnings and errors from the parser', () => {
+    const sampleEdifact = `UNA:+.? '
+UNB+UNOC:3+1234567891234:14+4321987654321:14+250725:1503+38190'
+UNH+3819000001+DESADV:D:01B:UN:EAN007'
+BGM+351+DES587441+9'
+DTM+137:20020401:102'
+UNT+7+3819000001'
+UNZ+1+38190'`;
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const service = new EdifactConversionService();
+    service.parse(sampleEdifact);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/nodes/__tests__/EdifactToJson.node.integration.spec.ts
+++ b/nodes/__tests__/EdifactToJson.node.integration.spec.ts
@@ -1,5 +1,5 @@
 
-import { EdifactParser } from "../EdifactToJson/parser";
+import { EdifactConversionService } from "../EdifactToJson/EdifactConversionService";
 
 
 describe('Edifact parsing', () => {
@@ -30,8 +30,8 @@ QTY+12:20'
 UNT+21+3819000001'
 UNZ+1+38190'`;
 
-    const parser = new EdifactParser(sampleEdifact);
-    var result = parser.parse();
+    const service = new EdifactConversionService();
+    const result = service.parse(sampleEdifact);
 
     expect(result.sender.id).toEqual('1234567891234');
     expect(result.receiver.id).toEqual('4321987654321');

--- a/nodes/__tests__/InputResolver.spec.ts
+++ b/nodes/__tests__/InputResolver.spec.ts
@@ -1,0 +1,63 @@
+import { InputResolver } from '../EdifactToJson/InputResolver';
+import { NodeOperationError } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeExecutionData } from 'n8n-workflow';
+
+describe('InputResolver', () => {
+  it('returns the string parameter when mainInputType is string', async () => {
+    const ctx = {
+      getNodeParameter: jest.fn()
+        .mockImplementation((name: string) => {
+          if (name === 'mainInputType') return 'string';
+          if (name === 'edifactInput') return 'EDIFACT_STRING';
+          return undefined;
+        }),
+      getInputData: jest.fn(),
+      helpers: { getBinaryDataBuffer: jest.fn() },
+      getNode: jest.fn(),
+    } as unknown as IExecuteFunctions;
+
+    const resolver = new InputResolver(ctx);
+    await expect(resolver.getEdifactString(0)).resolves.toBe('EDIFACT_STRING');
+  });
+
+  it('reads binary data when mainInputType is binary', async () => {
+    const buffer = Buffer.from('BINARY_EDIFACT');
+    const item = {
+      json: {},
+      binary: { data: { data: '', mimeType: 'text/plain' } },
+    } as INodeExecutionData;
+
+    const ctx = {
+      getNodeParameter: jest.fn()
+        .mockImplementation((name: string) => {
+          if (name === 'mainInputType') return 'binary';
+          if (name === 'binaryPropertyName') return 'data';
+          return undefined;
+        }),
+      getInputData: jest.fn().mockReturnValue([item]),
+      helpers: { getBinaryDataBuffer: jest.fn().mockResolvedValue(buffer) },
+      getNode: jest.fn(),
+    } as unknown as IExecuteFunctions;
+
+    const resolver = new InputResolver(ctx);
+    await expect(resolver.getEdifactString(0)).resolves.toBe('BINARY_EDIFACT');
+    expect(ctx.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'data');
+  });
+
+  it('throws NodeOperationError when binary data is missing', async () => {
+    const ctx = {
+      getNodeParameter: jest.fn()
+        .mockImplementation((name: string) => {
+          if (name === 'mainInputType') return 'binary';
+          if (name === 'binaryPropertyName') return 'data';
+          return undefined;
+        }),
+      getInputData: jest.fn().mockReturnValue([{ json: {} }]),
+      helpers: { getBinaryDataBuffer: jest.fn() },
+      getNode: jest.fn().mockReturnValue({}),
+    } as unknown as IExecuteFunctions;
+
+    const resolver = new InputResolver(ctx);
+    await expect(resolver.getEdifactString(0)).rejects.toBeInstanceOf(NodeOperationError);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `InputResolver` and `EdifactConversionService` for reusable logic
- refactor node to use these services
- update integration test to exercise new service API
- rename integration test file and add dedicated unit tests
- silence ts-edifact logging when parsing

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_b_6889aa8b2fac83338b275a5a6b758bf0